### PR TITLE
Fixed typo in FoBo.scala, knockout210 was pointing to knockout200

### DIFF
--- a/src/main/scala/net/liftmodules/FoBo/FoBo.scala
+++ b/src/main/scala/net/liftmodules/FoBo/FoBo.scala
@@ -170,7 +170,7 @@ object InitParam extends FoBoToolkit with FoBoJQuery {
  *  
  */
 case object Knockout210 extends FoBoToolkit {
-  FoBoResources.knockout200
+  FoBoResources.knockout210
 }
 /**
  * Enable usage of KnockOut version 2_1_0 in your bootstrap liftweb Boot.


### PR DESCRIPTION
Appears to be a typo in net.liftmodules.FoBo.FoBo where the code for Knockout 2.10 is actually calling Knockout 2.00.  Was:

```
case object Knockout210 extends FoBoToolkit {
  FoBoResources.knockout200
}
/**
 * Enable usage of KnockOut version 2_1_0 in your bootstrap liftweb Boot.
 * @version 2.1.0
 * 
 *  '''Example:'''
 *  
 * {{{
 *   FoBo.InitParam.Toolkit=FoBo.KnockOut210
 * }}}
 *  
 */
case object Knockout200 extends FoBoToolkit {
  FoBoResources.knockout200
}
...
```

Changed first `FoBoResources.knockout200` to `FoBoResources.knockout210`.
