### PR TITLE
Add BSLocInfo to Bootstrap 4 API

### DIFF
--- a/Bootstrap/Bootstrap4/TwBs-Bootstrap4-API/src/main/scala/net/liftmodules/fobobs4/lib/BSLocInfo.scala
+++ b/Bootstrap/Bootstrap4/TwBs-Bootstrap4-API/src/main/scala/net/liftmodules/fobobs4/lib/BSLocInfo.scala
@@ -1,0 +1,107 @@
+package net.liftmodules.fobobs4.lib
+
+/**
+  * Extends your Lift SiteMap with various common bootstrap menu manipulations such
+  * as horizontal and vertical menu dividers and menu labels (labels coming soon).
+  *
+  * This object should be used in conjunction with the TB* menu builder objects in [[net.liftmodules.fobo.snippet.FoBo]] snippet's.
+  *
+  * @example
+  * {{{
+  *   :
+  *  //add a horizontal menu divider
+  *  divider1 >> LocGroup(...) >> fobobs.BsLocInfo.Divider,
+  *   :
+  *  //add a vertical menu divider
+  *  divider2 >> LocGroup(...) >> fobobs.BsLocInfo.DividerVertical,
+  *   :
+  * }}}
+  */
+object BSLocInfo {
+  import net.liftweb.common.{Box, Full}
+
+  private val hd: Box[String] = Full("divider")
+  private val vd: Box[String] = Full("divider-vertical")
+  private val nh: Box[String] = Full("nav-header")
+
+  private val ltb: Box[String] = Full("_blank")
+  private val lts: Box[String] = Full("_self")
+  private val ltp: Box[String] = Full("_parent")
+  private val ltt: Box[String] = Full("_top")
+
+  /**
+    * Provides a way to specify a horizontal divider for your bootstrap menu in Lift's SiteMap.
+    *
+    * @example
+    * {{{
+    * val index            = Menu.i("Home") / "index"
+    *      :
+    * val about            = Menu.i("About") / "about"
+    * val divider2         = Menu("divider2") / "divider2" //dummy entry only showing a menu divider
+    * val navHeader1       = Menu.i("navHeader1") / "navHeader1" //Adds a header (label) to your FoBo.NavList
+    *
+    * def sitemap = SiteMap(
+    *   navHeader1 >> LocGroup("nl1") >> fobobs.BSLocInfo.NavHeader,
+    *   index >> LocGroup("top","nl1",...),
+    *    :
+    *   ddLabel >> LocGroup("top",...)  >> PlaceHolder submenus(
+    *       about ,
+    *       divider2 >> fobobs.BSLocInfo.Divider,
+    *       contact,
+    *       feedback
+    *       )
+    * )
+    * }}}
+    */
+  val Divider = new net.liftweb.sitemap.Loc.LocInfo[String] {
+    def apply() = hd.map(x => () => x)
+  }
+
+  /**
+    * Add a vertical divider in your bootstrap menu.
+    * For a usage example see the Divider val above.
+    */
+  val DividerVertical = new net.liftweb.sitemap.Loc.LocInfo[String] {
+    def apply() = vd.map(x => () => x)
+  }
+
+  /**
+    * Add nav header(s) to your bootstrap nav list.
+    * For a usage example see the NavHeader val above.
+    */
+  val NavHeader = new net.liftweb.sitemap.Loc.LocInfo[String] {
+    def apply() = nh.map(x => () => x)
+  }
+
+  /**
+    * Adds target="_blank" to the link
+    * @since v1.2
+    */
+  val LinkTargetBlank = new net.liftweb.sitemap.Loc.LocInfo[String] {
+    def apply() = ltb.map(x => () => x)
+  }
+
+  /**
+    * Adds target="_self" to the link
+    * @since v1.2
+    */
+  val LinkTargetSelf = new net.liftweb.sitemap.Loc.LocInfo[String] {
+    def apply() = lts.map(x => () => x)
+  }
+
+  /**
+    * Adds target="_parent" to the link
+    * @since v1.2
+    */
+  val LinkTargetParent = new net.liftweb.sitemap.Loc.LocInfo[String] {
+    def apply() = ltp.map(x => () => x)
+  }
+
+  /**
+    * Adds target="_top" to the link
+    * @since v1.2
+    */
+  val LinkTargetTop = new net.liftweb.sitemap.Loc.LocInfo[String] {
+    def apply() = ltt.map(x => () => x)
+  }
+}

--- a/Bootstrap/Bootstrap4/TwBs-Bootstrap4-API/src/main/scala/net/liftmodules/fobobs4/snippet/FoBo/Bs4LinkedListGroup.scala
+++ b/Bootstrap/Bootstrap4/TwBs-Bootstrap4-API/src/main/scala/net/liftmodules/fobobs4/snippet/FoBo/Bs4LinkedListGroup.scala
@@ -3,10 +3,9 @@ package net.liftmodules.fobobs4.snippet.FoBo
 import net.liftweb._
 import http._
 import common._
-import common.Box._
-import http.{S, LiftRules}
+import net.liftweb.util.Helpers
 import sitemap._
-import util.Helpers
+
 import xml._
 
 /**
@@ -49,9 +48,11 @@ import xml._
   *
   * '''Result:''' This will create a list group of linked items associated with the specified
   * LocGroup names 'lg1, user, lg2, ...'.
-  * @since v1.1
+  * @since v2.1
   */
 trait Bs4LinkedListGroup extends FlexMenuBuilder with DispatchSnippet {
+
+  private val logger = Logger(classOf[Bs4LinkedListGroup])
 
   def dispatch: DispatchIt =
     overridenDispatch orElse net.liftweb.builtin.snippet.Menu.dispatch
@@ -99,10 +100,11 @@ trait Bs4LinkedListGroup extends FlexMenuBuilder with DispatchSnippet {
 
   override def updateForCurrent(nodes: Elem, current: Boolean): Elem = nodes
 
+  //placeholder is disabled in render
   override def renderPlaceholder(item: MenuItem,
-                                 renderInner: Seq[MenuItem] => NodeSeq): Elem =
-    updateForCurrent(updateForPath({ item }.asInstanceOf[Elem], item.path),
-                     item.current)
+                                 renderInner: Seq[MenuItem] => NodeSeq): Elem = {
+    updateForCurrent(updateForPath({ item }.asInstanceOf[Elem], item.path), item.current)
+  }
 
   override def buildItemMenu[A](loc: Loc[A],
                                 currLoc: Box[Loc[_]],
@@ -219,6 +221,54 @@ trait Bs4LinkedListGroup extends FlexMenuBuilder with DispatchSnippet {
     }
   }
 
+  override def render: NodeSeq = {
+
+    val level: Box[Int] = for (lvs <- S.attr("level"); i <- Helpers.asInt(lvs)) yield i
+
+    val toRender: Seq[MenuItem] = this.toRender
+
+    def ifExpandCurrent(f: => NodeSeq): NodeSeq = if (expandAny || expandAll) f else NodeSeq.Empty
+    def ifExpandAll(f: => NodeSeq): NodeSeq = if (expandAll) f else NodeSeq.Empty
+    toRender.toList match {
+      case Nil if S.attr("group").isDefined => emptyGroup
+      case Nil => emptyMenu
+      case xs =>
+        def buildANavItem(i: MenuItem): NodeSeq = {
+          i match {
+            //disable placeholder regardless if it has kids or not
+            case m@MenuItem(text, uri, kids, _, _, _) if m.placeholder_? => emptyPlaceholder
+            // Per Loc.PlaceHolder, placeholder implies HideIfNoKids
+            /* case m@MenuItem(text, uri, kids, _, _, _) if m.placeholder_? && kids.isEmpty => emptyPlaceholder
+             case m@MenuItem(text, uri, kids, _, _, _) if m.placeholder_? => renderPlaceholder(m, buildLine _)*/
+            case m@MenuItem(text, uri, kids, true, _, _) if linkToSelf   => renderSelfLinked(m, k => ifExpandCurrent(buildLine(k)))
+            case m@MenuItem(text, uri, kids, true, _, _) => renderSelfNotLinked(m, k => ifExpandCurrent(buildLine(k)))
+            // Not current, but on the path, so we need to expand children to show the current one
+            case m@MenuItem(text, uri, kids, _, true, _) => renderItemInPath(m, buildLine _)
+            case m =>renderItem(m, buildLine _)
+          }
+        }
+
+        def buildLine(in: Seq[MenuItem]): NodeSeq = buildUlLine(in, false)
+
+        def buildUlLine(in: Seq[MenuItem], top: Boolean): NodeSeq =
+          if (in.isEmpty) {
+            NodeSeq.Empty
+          } else {
+            renderOuterTag(in.flatMap(buildANavItem), top)
+          }
+
+        val realMenuItems = level match {
+          case Full(lvl) if lvl > 0 =>
+            def findKids(cur: Seq[MenuItem], depth: Int): Seq[MenuItem] = if (depth == 0) cur
+            else findKids(cur.flatMap(mi => mi.kids), depth - 1)
+
+            findKids(xs, lvl)
+
+          case _ => xs
+        }
+        buildUlLine(realMenuItems, true)
+    }
+  }
 }
 
 object Bs4LinkedListGroup extends Bs4LinkedListGroup


### PR DESCRIPTION
**Problem**: BSLockInfo is missing from fobo's bootstrap 4 toolkit

**Solution**: Add BSLockInfo to fobo's bootstrap 4 api.

**Changes introduced by this pull request**:

- Bootstrap/Bootstrap4/TwBs-Botstrap4-API

**Connected to**: Connected to #176 

**Fixes**: Fixes #176 